### PR TITLE
Tweak subscriber

### DIFF
--- a/src/DebugbarSubscriber.php
+++ b/src/DebugbarSubscriber.php
@@ -1,34 +1,33 @@
 <?php
 namespace GuzzleHttp\Subscriber\Log;
 
-use DebugBar\DataCollector\ExceptionsCollector;
 use DebugBar\DataCollector\TimeDataCollector;
 use GuzzleHttp\Event\BeforeEvent;
 use GuzzleHttp\Event\CompleteEvent;
 use GuzzleHttp\Event\ErrorEvent;
 use GuzzleHttp\Event\SubscriberInterface;
 use GuzzleHttp\Message\RequestInterface;
+use GuzzleHttp\Message\ResponseInterface;
+use DebugBar\DebugBarException;
 
 class DebugbarSubscriber implements SubscriberInterface
 {
     /**
      * @var TimeDataCollector
      */
-    private $timeline;
+    protected $timeline;
 
     /**
-     * @var ExceptionsCollector
+     * @var array
      */
-    private $exceptions;
+    protected $startedMeasures = array();
 
     /**
      * @param TimeDataCollector   $timeline
-     * @param ExceptionsCollector $exceptions
      */
-    public function __construct(TimeDataCollector $timeline, ExceptionsCollector $exceptions)
+    public function __construct(TimeDataCollector $timeline)
     {
         $this->timeline   = $timeline;
-        $this->exceptions = $exceptions;
     }
 
     /**
@@ -48,14 +47,8 @@ class DebugbarSubscriber implements SubscriberInterface
      */
     public function onBefore(BeforeEvent $event)
     {
-        // Make up an identifier.
-        $identifier = $this->createTimelineID($event->getRequest());
-
-        // Construct a timeline message
-        $message = $this->createTimelineMessage($event->getRequest());
-
         // Start time tracking.
-        $this->timeline->startMeasure($identifier, $message);
+        $this->startMeasure($event->getRequest());
     }
 
     /**
@@ -64,7 +57,7 @@ class DebugbarSubscriber implements SubscriberInterface
     public function onComplete(CompleteEvent $event)
     {
         // Stop measurement.
-        $this->stopMeasure($event->getRequest());
+        $this->stopMeasure($event->getRequest(), $event->getResponse());
     }
 
     /**
@@ -72,20 +65,108 @@ class DebugbarSubscriber implements SubscriberInterface
      */
     public function onError(ErrorEvent $event)
     {
-        // Stop tracking the request.
-        $this->stopMeasure($event->getRequest());
-
-        // And log the exception.
-        $this->exceptions->addException($event->getException());
+        // Stop measurement and add exception information.
+        $this->stopMeasure($event->getRequest(), $event->getResponse(), $event->getException());
     }
 
     /**
-     * @param RequestInterface $request
+     * Start a measure
+     *
+     * @param RequestInterface  $request
      */
-    private function stopMeasure(RequestInterface $request)
+    protected function startMeasure(RequestInterface $request)
     {
-        // Stop time tracking.
-        $this->timeline->stopMeasure($this->createTimelineID($request));
+        // Make up an identifier.
+        $name = $this->createTimelineID($request);
+
+        $this->startedMeasures[$name] = microtime(true);
+    }
+
+    /**
+     * Stop the measurement
+     *
+     * @param RequestInterface $request
+     * @param ResponseInterface $response
+     * @param \Exception $error
+     *
+     * @throws DebugBarException
+     */
+    protected function stopMeasure(RequestInterface $request, ResponseInterface $response = null, \Exception $error = null)
+    {
+        $end = microtime(true);
+        $name = $this->createTimelineID($request);
+
+        if (!isset($this->startedMeasures[$name])) {
+            throw new DebugBarException("Failed stopping measure '$name' because it hasn't been started");
+        }
+
+        $this->timeline->addMeasure(
+            $this->createTimelineMessage($request, $response),
+            $this->startedMeasures[$name],
+            $end,
+            $this->getParameters($request, $response, $error),
+            'guzzle'
+        );
+
+        unset($this->startedMeasures[$name]);
+    }
+
+    protected function getParameters(RequestInterface $request, ResponseInterface $response = null, \Exception $error = null)
+    {
+        $params = array();
+        if($error){
+            $params['error'] = $error->getMessage();
+        }
+        $keys = array(
+            'method', 'url', 'host', 'code', 'phrase', 'request', 'response',
+        );
+        foreach($keys as $key){
+            $result = '';
+            switch ($key) {
+                case 'request':
+                    $result = $request;
+                    break;
+                case 'response':
+                    $result = $response;
+                    break;
+                case 'method':
+                    $result = $request->getMethod();
+                    break;
+                case 'url':
+                    $result = $request->getUrl();
+                    break;
+                case 'resource':
+                    $result = $request->getResource();
+                    break;
+                case 'req_version':
+                    $result = $request->getProtocolVersion();
+                    break;
+                case 'res_version':
+                    $result = $response
+                        ? $response->getProtocolVersion()
+                        : 'NULL';
+                    break;
+                case 'host':
+                    $result = $request->getHost();
+                    break;
+                case 'hostname':
+                    $result = gethostname();
+                    break;
+                case 'code':
+                    $result = $response
+                        ? $response->getStatusCode()
+                        : 'NULL';
+                    break;
+                case 'phrase':
+                    $result = $response
+                        ? $response->getReasonPhrase()
+                        : 'NULL';
+                    break;
+            }
+            $params[$key] = (string) $result;
+        }
+
+        return $params;
     }
 
     /**
@@ -109,12 +190,14 @@ class DebugbarSubscriber implements SubscriberInterface
     }
 
     /**
-     * @param RequestInterface $request
+     * @param RequestInterface  $request
+     * @param ResponseInterface $response
      *
      * @return string
      */
-    private function createTimelineMessage(RequestInterface $request)
+    private function createTimelineMessage(RequestInterface $request, ResponseInterface $response = null)
     {
-        return sprintf('Performing a %s request to %s.', $request->getMethod(), $request->getHeader('Host'));
+        $code = $response ? $response->getStatusCode() : 'NULL';
+        return sprintf('%s %s (%s)', $request->getMethod(), $request->getUrl(), $code);
     }
 }


### PR DESCRIPTION
Here are some possible changes. This is what I used recently, so might not be optimal yet.

Some things:
 - Skip the ExceptionCollector, show Exceptions in the TimeData Collector
 - Tweak the label to include the url and statuscode
 - Show detailed parameters in the results.

Because I wanted to show the status in the label, I needed to change the way the measurement is added.

The keys that are shown should probably be configurable, perhaps by using a second argument with an array of parameter keys. (I thought I had that somewhere, but might be a different project, so have to look).