### PR TITLE
Fix binding issue in Laravel service provider

### DIFF
--- a/src/Support/Laravel/ServiceProvider.php
+++ b/src/Support/Laravel/ServiceProvider.php
@@ -44,7 +44,7 @@ class ServiceProvider extends BaseServiceProvider
         $this->app->alias(ClientInterface::class, Client::class);
 
         // Bind if needed.
-        $this->app->bindIf(HandlerStack::class, function () {
+        $this->app->bind(HandlerStack::class, function () {
             return HandlerStack::create();
         });
 


### PR DESCRIPTION
I do not believe the provided Laravel service provider works correctly, at least not with the current version of Laravel.

The current use of `bindIf` means that the `HandlerStack` does not get bound in the container with an instance created using `HandlerStack::create()`, as is intended. The reason for this is:
- `bindIf` calls `Illuminate\Foundation\Application::bound`:
```php
public function bound($abstract)
{
    return isset($this->deferredServices[$abstract]) || parent::bound($abstract);
}
```
- because this package's service provided is marked as deferred, the `deferredServices` array will contain `'GuzzleHttp\\HandlerStack' => 'GuzzleHttp\\Profiling\\Debugbar\\Support\\Laravel\\ServiceProvider',`
- hence `bindIf` will consider `HandlerStack` to have already been bound.
- the solution, therefore, is to just use `bind` and not `bindIf`, thereby getting a fully constructed instance of `HandlerStack` into the IoC.