### PR TITLE
Update ServiceProvider.php

### DIFF
--- a/src/Support/Laravel/ServiceProvider.php
+++ b/src/Support/Laravel/ServiceProvider.php
@@ -51,7 +51,7 @@ class ServiceProvider extends BaseServiceProvider
         // If resolved, by this SP or another, add some layers.
         $this->app->resolving(HandlerStack::class, function (HandlerStack $stack) {
             // We cannot log with debugbar from the CLI
-            if (\App::runningInConsole()) {
+            if ($this->app->runningInConsole()) {
                 return;
             }
             

--- a/src/Support/Laravel/ServiceProvider.php
+++ b/src/Support/Laravel/ServiceProvider.php
@@ -50,6 +50,11 @@ class ServiceProvider extends BaseServiceProvider
 
         // If resolved, by this SP or another, add some layers.
         $this->app->resolving(HandlerStack::class, function (HandlerStack $stack) {
+            // We cannot log with debugbar from the CLI
+            if (\App::runningInConsole()) {
+                return;
+            }
+            
             /** @var \DebugBar\DebugBar $debugBar */
             $debugBar = $this->app->make('debugbar');
 


### PR DESCRIPTION
Debugbar's collectors aren't registered in the CLI, giving an error that the time collector doesn't exist.