### PR TITLE
Check required collectors before getting them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: php
+sudo: false
 
 matrix:
   include:
     - php: 5.5
     - php: 5.6
-      env: COLLECT_COVERAGE=true
     - php: 7.0
-    - php: hhvm
+    - php: 7.1
+    - php: 7.2
+      env: COLLECT_COVERAGE=true
 
 install:
   - travis_retry composer self-update

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 Guzzle middleware to log requests to DebugBar's timeline.
 
-![Debugbar timeline](https://www.dropbox.com/s/cabwqycckbu681b/debugbar-timeline.png?dl=1 "Debugbar timeline")
-![Debugbar logs](https://www.dropbox.com/s/7rez2q1mbrl76yq/debugbar-logs.png?dl=1 "Debugbar logs")
+![Debugbar timeline](https://www.dropbox.com/s/zjx0mtgauhm9dx5/debugbar-timeline.png?dl=1 "Debugbar timeline")
+![Debugbar logs](https://www.dropbox.com/s/7plrqf6mlyz3e4v/debugbar-logs.png?dl=1 "Debugbar logs")
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $debugBar = new StandardDebugBar();
 $logger = $debugBar->getCollector('messages');
 
 // Create a new Log middleware.
-$stack->push(GuzzleHttp\Middleware::log($logger));
+$stack->push(GuzzleHttp\Middleware::log($logger, new GuzzleHttp\MessageFormatter()));
 
 // New up the client with this handler stack.
 $client = new GuzzleHttp\Client(['handler' => $stack]);

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 Guzzle middleware to log requests to DebugBar's timeline.
 
-![Debugbar timeline](https://www.dropbox.com/s/zjx0mtgauhm9dx5/debugbar-timeline.png?dl=1 "Debugbar timeline")
-![Debugbar logs](https://www.dropbox.com/s/7plrqf6mlyz3e4v/debugbar-logs.png?dl=1 "Debugbar logs")
+![Debugbar timeline](https://www.dropbox.com/s/zjx0mtgauhm9dx5/debugbar-timeline.png?dl=1)
+![Debugbar logs](https://www.dropbox.com/s/7plrqf6mlyz3e4v/debugbar-logs.png?dl=1)
 
 ## Usage
 

--- a/src/Support/Laravel/ServiceProvider.php
+++ b/src/Support/Laravel/ServiceProvider.php
@@ -52,25 +52,31 @@ class ServiceProvider extends BaseServiceProvider
         $this->app->resolving(HandlerStack::class, function (HandlerStack $stack) {
             /** @var \DebugBar\DebugBar $debugBar */
             $debugBar = $this->app->make('debugbar');
+            
+            if (
+              $debugBar->hasCollector('exceptions') &&
+              $debugBar->hasCollector('messages') &&
+              $debugBar->hasCollector('time')
+            ) {
+                $stack->push(new Middleware(new Profiler($timeline = $debugBar->getCollector('time'))));
+                $stack->unshift(new ExceptionMiddleware($debugBar->getCollector('exceptions')));
 
-            $stack->push(new Middleware(new Profiler($timeline = $debugBar->getCollector('time'))));
-            $stack->unshift(new ExceptionMiddleware($debugBar->getCollector('exceptions')));
+                /** @var \GuzzleHttp\MessageFormatter $formatter */
+                $formatter = $this->app->make(MessageFormatter::class);
+                $stack->unshift(GuzzleMiddleware::log($debugBar->getCollector('messages'), $formatter));
 
-            /** @var \GuzzleHttp\MessageFormatter $formatter */
-            $formatter = $this->app->make(MessageFormatter::class);
-            $stack->unshift(GuzzleMiddleware::log($debugBar->getCollector('messages'), $formatter));
+                // Also log to the default PSR logger.
+                if ($this->app->bound(LoggerInterface::class)) {
+                    $logger = $this->app->make(LoggerInterface::class);
 
-            // Also log to the default PSR logger.
-            if ($this->app->bound(LoggerInterface::class)) {
-                $logger = $this->app->make(LoggerInterface::class);
+                    // Don't log to the same logger twice.
+                    if ($logger === $debugBar->getCollector('messages')) {
+                        return;
+                    }
 
-                // Don't log to the same logger twice.
-                if ($logger === $debugBar->getCollector('messages')) {
-                    return;
+                    // Push the middleware on the stack.
+                    $stack->unshift(GuzzleMiddleware::log($logger, $formatter));
                 }
-
-                // Push the middleware on the stack.
-                $stack->unshift(GuzzleMiddleware::log($logger, $formatter));
             }
         });
     }

--- a/tests/unit/ProfilerTest.php
+++ b/tests/unit/ProfilerTest.php
@@ -61,7 +61,7 @@ class ProfilerTest extends PHPUnit_Framework_TestCase
             'resource' => 'http://httpbin.org/status/418',
             'request_version' => '1.1',
             'response_version' => '1.1',
-            'hostname' => gethostname(),
+            'hostname' => php_uname('n'),
         ];
 
         // Set expectations


### PR DESCRIPTION
If required collectors are not available or DebugBar is disabled it's a good idea to check if they are present before trying to use them.