### PR TITLE
Add a check for collectors present to Laravel ServiceProvider 

### DIFF
--- a/src/Support/Laravel/ServiceProvider.php
+++ b/src/Support/Laravel/ServiceProvider.php
@@ -53,14 +53,15 @@ class ServiceProvider extends BaseServiceProvider
             /** @var \DebugBar\DebugBar $debugBar */
             $debugBar = $this->app->make('debugbar');
 
-            if (
-              $debugBar->hasCollector('exceptions') &&
-              $debugBar->hasCollector('messages') &&
-              $debugBar->hasCollector('time')
-            ) {
+            if ($debugBar->hasCollector('time')) {
               $stack->push(new Middleware(new Profiler($timeline = $debugBar->getCollector('time'))));
-              $stack->unshift(new ExceptionMiddleware($debugBar->getCollector('exceptions')));
+            }
 
+            if ($debugBar->hasCollector('exceptions')) {
+              $stack->unshift(new ExceptionMiddleware($debugBar->getCollector('exceptions')));
+            }
+
+            if ($debugBar->hasCollector('messages')) {
               /** @var \GuzzleHttp\MessageFormatter $formatter */
               $formatter = $this->app->make(MessageFormatter::class);
               $stack->unshift(GuzzleMiddleware::log($debugBar->getCollector('messages'), $formatter));


### PR DESCRIPTION
This prevents errors when DebugBar is not enabled, for example when used in CLI.

P.S. Had to modify a test that was failing and made a mess in the first pull request.