### PR TITLE
build: use new Debugbar package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=7.2",
         "hannesvdvreken/guzzle-profiler": "^2",
-        "maximebf/debugbar": "^1"
+        "php-debugbar/php-debugbar": "^1"
     },
     "require-dev": {
         "illuminate/support": ">=6",


### PR DESCRIPTION
The package has been renamed from `maximebf/debugbar` to `php-debugbar/php-debugbar`.

See: https://packagist.org/packages/maximebf/debugbar